### PR TITLE
Generalise component update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note : This project has been tested only in Preact, but it should work in React 
 | **hasError('fieldName','errorName')** | Return true if the given field has the given error |
 | **getValues()** | Return the form values |
 | **getValue('fieldName')** | Return the saved value |
-| **setValue('fieldName','value', component?)** | Update a form value programatically - _form will be re-validate automatically_ |
+| **setValue('fieldName','value', updateFunc?)** | Update a form value programatically - _form will be re-validate automatically_ |
 | **isValid()** | Return if the form is currently valid |
 | **isSelected('fieldName','value')** | Return true if the current value of the given field is equals the entry value (Useful when dealing with checkboxes and radio buttons) |
 
@@ -106,12 +106,12 @@ import { Form, Validators, validateField } from 'preact-forms-helpers';
 
 ```
 
-To finish, we create the input field and call the _validateField_ function (with component and form as argument)
+To finish, we create the input field and call the _validateField_ function (with component update function and form as argument)
 ```
 import { Form, Validators, validateField } from 'preact-forms-helpers';
 
 ...
-<input type="text" name="firstname" onInput={validateField(this, form)} />
+<input type="text" name="firstname" onInput={validateField(this.forceUpdate, form)} />
 ...
 ```
 What will happen ? On every input from user, the form will be updated, giving you if :
@@ -122,7 +122,7 @@ Then the component will be _forceUpdate()_
 
  **Important :**
 The library make the connection between between the form class property and the input by using the input _name_ attribute. As you can see, we got `firstname: { validators: [...] }` and `<input type="text" name="firstname" />`.  
-If you want to use different name between the property and the input, _validateField_ accepts a third argument : `onInput={validateField(this, form, 'myCustomPropertyName')}`
+If you want to use different name between the property and the input, _validateField_ accepts a third argument : `onInput={validateField(this.forceUpdate, form, 'myCustomPropertyName')}`
 
 To finish, you can check global state of the form by using `this.state.form.isValid()`
 ```

--- a/src/form/index.js
+++ b/src/form/index.js
@@ -120,10 +120,10 @@ export default class Form {
     return this.values[fieldName];
   }
 
-  setValue(fieldName, value, component) {
+  setValue(fieldName, value, updateFunc) {
     this.checkFieldExists(fieldName);
     this.values[fieldName] = value;
-    this.validateField(fieldName, value, component ? () => component.forceUpdate() : undefined);
+    this.validateField(fieldName, value, updateFunc ? () => updateFunc() : undefined);
   }
 
   getValues() { return this.values; }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,7 +20,7 @@ declare module "preact-forms-helper" {
     constructor(formData: T);
     updateValidators(newFormValidators: T): void;
     saveField<K extends keyof T>(name: K, value: GetType<GetFieldValue<T[K]>>): GetFieldValue<T[K]>;
-    validateField<K extends keyof T>(name: K, value: GetFieldValue<T[K]>, forceUpdate: boolean): void;
+    validateField<K extends keyof T>(name: K, value: GetFieldValue<T[K]>, forceUpdateFn: Function): void;
     checkFieldExists<K extends keyof T>(name: K): boolean;
     updateFormStatus(): void;
     hasErrors<K extends keyof T>(name: K): boolean;
@@ -29,7 +29,7 @@ declare module "preact-forms-helper" {
     hasError<K extends keyof T>(name: K, errorName: string): boolean;
     isSelected<K extends keyof T>(name: K, value: GetType<GetFieldValue<T[K]>>): boolean;
     getValue<K extends keyof T>(name: K): GetFieldValue<T[K]>;
-    setValue<K extends keyof T>(name: K, value: GetFieldValue<T[K]>, component: Preact.AnyComponent): void;
+    setValue<K extends keyof T>(name: K, value: GetFieldValue<T[K]>, updateFunc: Function): void;
     getValues(): boolean;
     isValid(): boolean;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export const validateField = (component, form, fieldName) => {
+export const validateField = (updateFunc, form, fieldName) => {
   return function(event) {
     // Name
     fieldName = fieldName || event.target.name;
@@ -15,7 +15,7 @@ export const validateField = (component, form, fieldName) => {
 
     let newValue = form.saveField(fieldName, value);
     // Check and forceUpdate
-    form.validateField(fieldName, newValue, () => component.forceUpdate())
+    form.validateField(fieldName, newValue, () => updateFunc())
   };
 }
 


### PR DESCRIPTION
This is breaking change, the signatures of validateField() function and
Form.setValue() method now take function to be called to force update
component instead of class based component instance. This way the
library may be usable also in code that uses functional components where
there's no 'this'.